### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "pybind11"
+description := "A lightweight header-only library that exposes C++ types in Python and vice versa, mainly to create Python bindings of existing C++ code."
+gitrepo     := "https://github.com/pybind/pybind11.git"
+homepage    := "http://pybind11.readthedocs.org"
+version     := 2.4.3 sha256:1eed57bc6863190e35637290f97a20c81cfe4d9090ac0a24f3bbf08f265eb71d https://github.com/pybind/pybind11/archive/v2.4.3.tar.gz
+license     := "BSD-3-Clause"


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

